### PR TITLE
Put environmental variables into namespace to prevent conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,18 @@ The following parameters need to be passed as environment variables to the conta
 
 |Name|Description|Mandatory|Default| 
 |---|---|---|---|
-|ELASTICSEARCH_ADDR|Your Elasticsearch cluster address to monitor (preferably, the ip/hostname of one of your client nodes) - the protocol and port are not required|Yes|-|
-|GRAPHITE|The graphite server the metrics should end up in|Yes|-|
-|ELASTICSEARCH_PROTOCOL|http or https. Upper or lower case are acceptable. Typos arre knot.|No|http| 
-|ELASTICSEARCH_PORT|Port number (usually 9200)|No|9200| 
-|ELASTICSEARCH_USER_NAME|Username for basic auth|No|| 
-|ELASTICSEARCH_PASSWORD|Password for basic auth|No||
-|GRAPHITE_PREFIX|The prefix under graphite you want your metrics in. We will add the cluster name, and the node name after that|No|Elasticsearch|
-|GRAPHITE_PROTOCOL|Graphite protocol. Allowed values are 'pickle' or 'plaintext'|No|pickle|
-|GRAPHITE_PORT|Graphite port|No|2004|
-|INTERVAL_SECONDS|The frequency in which Elasticsearch is to be sampled (preferably, the same value as your graphite configured metrics interval)|No|10|
-|BULK_SIZE|The amount of metrics to be sent in each bulk request|No|50|
-|MAX_RETRY_BULK|The number of repeated attempts to send a bulk that failed on IOError (originated from graphite)|No|3|
+|ES2GRAPHITE_ELASTICSEARCH_ADDR|Your Elasticsearch cluster address to monitor (preferably, the ip/hostname of one of your client nodes) - the protocol and port are not required|Yes|-|
+|ES2GRAPHITE_GRAPHITE|The graphite server the metrics should end up in|Yes|-|
+|ES2GRAPHITE_ELASTICSEARCH_PROTOCOL|http or https. Upper or lower case are acceptable. Typos arre knot.|No|http| 
+|ES2GRAPHITE_ELASTICSEARCH_PORT|Port number (usually 9200)|No|9200| 
+|ES2GRAPHITE_ELASTICSEARCH_USER_NAME|Username for basic auth|No|| 
+|ES2GRAPHITE_ELASTICSEARCH_PASSWORD|Password for basic auth|No||
+|ES2GRAPHITE_GRAPHITE_PREFIX|The prefix under graphite you want your metrics in. We will add the cluster name, and the node name after that|No|Elasticsearch|
+|ES2GRAPHITE_GRAPHITE_PROTOCOL|Graphite protocol. Allowed values are 'pickle' or 'plaintext'|No|pickle|
+|ES2GRAPHITE_GRAPHITE_PORT|Graphite port|No|2004|
+|ES2GRAPHITE_INTERVAL_SECONDS|The frequency in which Elasticsearch is to be sampled (preferably, the same value as your graphite configured metrics interval)|No|10|
+|ES2GRAPHITE_BULK_SIZE|The amount of metrics to be sent in each bulk request|No|50|
+|ES2GRAPHITE_MAX_RETRY_BULK|The number of repeated attempts to send a bulk that failed on IOError (originated from graphite)|No|3|
 
 
 ## Path in graphite
@@ -34,14 +34,14 @@ Elasticsearch.prefix.MY_ES_CLUSTER.node1.jvm.mem.heap_used_percent
 ## Run Examples
 ```bash
 docker run --restart=always -d --name="es2graphite" \
-                        -e ELASTICSEARCH_ADDR="es-client.internal.domain.example" \
-                        -e GRAPHITE="graphite.internal.domain.example" \
-                        -e ELASTICSEARCH_PROTOCOL="https" \
-                        -e ELASTICSEARCH_USER_NAME="mahUser" \
-                        -e ELASTICSEARCH_PASSWORD="mahPassword" 
-                        -e GRAPHITE_PREFIX="PROD.Elasticsearch" \
-                        -e INTERVAL_SECONDS=20 \
-                        -e BULK_SIZE=10 \
+                        -e ES2GRAPHITE_ELASTICSEARCH_ADDR="es-client.internal.domain.example" \
+                        -e ES2GRAPHITE_GRAPHITE="graphite.internal.domain.example" \
+                        -e ES2GRAPHITE_ELASTICSEARCH_PROTOCOL="https" \
+                        -e ES2GRAPHITE_ELASTICSEARCH_USER_NAME="mahUser" \
+                        -e ES2GRAPHITE_ELASTICSEARCH_PASSWORD="mahPassword" 
+                        -e ES2GRAPHITE_GRAPHITE_PREFIX="PROD.Elasticsearch" \
+                        -e ES2GRAPHITE_INTERVAL_SECONDS=20 \
+                        -e ES2GRAPHITE_BULK_SIZE=10 \
                         logzio/es2graphite
 ```
 

--- a/logzio-es2graphite/scripts/go.py
+++ b/logzio-es2graphite/scripts/go.py
@@ -8,19 +8,19 @@
 #
 # Params:
 #   Mandatory:
-#       GRAPHITE - The graphite server to send metrics to
-#       ELASTICSEARCH_ADDR - The elasticsearch cluster to monitor
+#       ES2GRAPHITE_GRAPHITE - The graphite server to send metrics to
+#       ES2GRAPHITE_ELASTICSEARCH_ADDR - The elasticsearch cluster to monitor
 #
 #   Optional:
-#       ELASTICSEARCH_PROTOCOL: http or https. Defaults to http.
-#       ELASTICSEARCH_USER_NAME: Elasticsearch user name to use for basic auth
-#       ELASTICSEARCH_PASSWORD: Elasticsearch password to use for basic auth
-#       GRAPHITE_PREFIX - The prefix under graphite the metrics should be placed in (Default: Elasticsearch)
-#       GRAPHITE_PROTOCOL - The protocol used to send data to graphite (Default: pickle. Can be either pickle or plaintext)
-#       GRAPHITE_PORT - Graphite port (Default: 2004)
-#       INTERVAL_SECONDS - The sample interval (Default: 10)
-#       BULK_SIZE - The amount of metrics to be sent in each bulk request (Default: 50)
-#       MAX_RETRY_BULK - The number of repeated attempts to send a bulk upon IOError failure (Default: 3)
+#       ES2GRAPHITE_ELASTICSEARCH_PROTOCOL: http or https. Defaults to http.
+#       ES2GRAPHITE_ELASTICSEARCH_USER_NAME: Elasticsearch user name to use for basic auth
+#       ES2GRAPHITE_ELASTICSEARCH_PASSWORD: Elasticsearch password to use for basic auth
+#       ES2GRAPHITE_GRAPHITE_PREFIX - The prefix under graphite the metrics should be placed in (Default: Elasticsearch)
+#       ES2GRAPHITE_GRAPHITE_PROTOCOL - The protocol used to send data to graphite (Default: pickle. Can be either pickle or plaintext)
+#       ES2GRAPHITE_GRAPHITE_PORT - Graphite port (Default: 2004)
+#       ES2GRAPHITE_INTERVAL_SECONDS - The sample interval (Default: 10)
+#       ES2GRAPHITE_BULK_SIZE - The amount of metrics to be sent in each bulk request (Default: 50)
+#       ES2GRAPHITE_MAX_RETRY_BULK - The number of repeated attempts to send a bulk upon IOError failure (Default: 3)
 
 
 import os
@@ -34,27 +34,27 @@ from time import sleep, time
 import requests
 
 # Get mandatory variables
-elasticsearchAddr = os.getenv('ELASTICSEARCH_ADDR')
-graphite = os.getenv('GRAPHITE')
+elasticsearchAddr = os.getenv('ES2GRAPHITE_ELASTICSEARCH_ADDR')
+graphite = os.getenv('ES2GRAPHITE_GRAPHITE')
 
 # Gets optional variables
-elasticsearch_port = os.getenv('ELASTICSEARCH_PORT', '9200')
-elasticsearch_protocol = os.getenv('ELASTICSEARCH_PROTOCOL', 'http').lower()
-elasticsearch_user_name = os.getenv('ELASTICSEARCH_USER_NAME', '')
-elasticsearch_password = os.getenv('ELASTICSEARCH_PASSWORD', '')
-graphite_prefix = os.getenv('GRAPHITE_PREFIX', "Elasticsearch")
-graphite_port = os.getenv('GRAPHITE_PORT', '2004')
-graphite_protocol = os.getenv('GRAPHITE_PROTOCOL', 'pickle')
-interval = os.getenv('INTERVAL_SECONDS', 10)
-bulk_size = os.getenv('BULK_SIZE', 50)
-max_retry_bulk = os.getenv('MAX_RETRY_BULK', 3)
+elasticsearch_port = os.getenv('ES2GRAPHITE_ELASTICSEARCH_PORT', '9200')
+elasticsearch_protocol = os.getenv('ES2GRAPHITE_ELASTICSEARCH_PROTOCOL', 'http').lower()
+elasticsearch_user_name = os.getenv('ES2GRAPHITE_ELASTICSEARCH_USER_NAME', '')
+elasticsearch_password = os.getenv('ES2GRAPHITE_ELASTICSEARCH_PASSWORD', '')
+graphite_prefix = os.getenv('ES2GRAPHITE_GRAPHITE_PREFIX', "Elasticsearch")
+graphite_port = os.getenv('ES2GRAPHITE_GRAPHITE_PORT', '2004')
+graphite_protocol = os.getenv('ES2GRAPHITE_GRAPHITE_PROTOCOL', 'pickle')
+interval = os.getenv('ES2GRAPHITE_INTERVAL_SECONDS', 10)
+bulk_size = os.getenv('ES2GRAPHITE_BULK_SIZE', 50)
+max_retry_bulk = os.getenv('ES2GRAPHITE_MAX_RETRY_BULK', 3)
 
 
 # Check if both mandatory are set
 if not all([elasticsearchAddr, graphite]):
     print ("#############################################################################################")
     print ("You must supply your ElasticSearch ip/hostname and Graphite server")
-    print ("docker run .... -e ELASTICSEARCH_ADDR=<Elasticsearch Address> -e GRAPHITE=<Graphite address>....")
+    print ("docker run .... -e ES2GRAPHITE_ELASTICSEARCH_ADDR=<Elasticsearch Address> -e ES2GRAPHITE_GRAPHITE=<Graphite address>....")
     print ("#############################################################################################")
 
     sys.exit(1)


### PR DESCRIPTION
As noted in the issue I filed, I'm running this in kubernetes and it is populating an environmental variable that conflicts with what this previously assumed. 